### PR TITLE
Change the check for rvm:hook

### DIFF
--- a/lib/capistrano/tasks/deface.cap
+++ b/lib/capistrano/tasks/deface.cap
@@ -11,7 +11,7 @@ namespace :deface do
   end
 
   # RVM integration
-  if Gem::Specification::find_all_by_name('capistrano-rvm').any?
+  if Rake.application.tasks.collect(&:to_s).include?("rvm:hook")
     before :precompile, 'rvm:hook'
   end
 end


### PR DESCRIPTION
I'm loading capistrano-rvm only in staging environment, not in production, but the gem is always present in Gemfile, so deployment fails because we call a task that doesn't exist.
